### PR TITLE
fix hydrated class for sl-drawer after reflex

### DIFF
--- a/app/javascript/spreadsheet/controllers/sheet_controller.js
+++ b/app/javascript/spreadsheet/controllers/sheet_controller.js
@@ -11,7 +11,10 @@ export default class extends Controller {
     document.addEventListener('spreadsheet:cell-focus', this.clearSum.bind(this))
 
     window.addEventListener('cable-ready:after-morph', function (event) {
-      const tags = ['sl-dropdown', 'sl-menu', 'sl-menu-item', 'sl-menu-label', 'sl-icon', 'sl-icon-button', 'sl-input', 'sl-checkbox', 'sl-switch', 'sl-button']
+      const tags = [
+        'sl-dropdown', 'sl-menu', 'sl-menu-item', 'sl-menu-label', 'sl-icon', 'sl-icon-button',
+        'sl-input', 'sl-checkbox', 'sl-switch', 'sl-button', 'sl-drawer'
+      ]
       tags.forEach(tag => {
         document.querySelectorAll(tag).forEach(el => {
           el.classList.add('hydrated')


### PR DESCRIPTION
Quick info
---

Fix hydrated class for the `sl-drawer` component after a reflex action.

Migrations?
---

:-1:

What does this change?
---

- [x] Fixes the `sl-drawer` component.

Why are you changing that?
---

After the morph event to re-render the HTML with action-cable and stimulus reflex, the `hydrated` class for the shoelace `sl-drawer` component is not loaded.