### PR TITLE
Move from with_content_areas to ViewComponent slots

### DIFF
--- a/app/components/spreadsheet/cell.haml
+++ b/app/components/spreadsheet/cell.haml
@@ -5,13 +5,13 @@
     - if expander
       .collapse-control.inline-block.transform.transition-transform.duration-200.ease-in.cursor-pointer{ data: { action: "click->#{parent_component_controller}#collapse" }}
         %sl-icon{ name: "caret-down-fill" }
-    - if actions_menu
+    - if cell_actions_menu
       %sl-dropdown.cell_actionmenu
         .p-1.text-gray-500.cursor-pointer(slot="trigger"){class: actions_menu_label_classes}
           %sl-icon(name=actions_menu_icon)
           = actions_menu_label
         %sl-menu.text-xs
-          = actions_menu
+          = cell_actions_menu
 
   - unless readonly
     %input.bg-white.text-black.w-full.p-1.hidden{id: random_id, type: "text", value: value, class: numeric_class, disabled: disabled, readonly: readonly, data: input_data }

--- a/app/components/spreadsheet/cell.rb
+++ b/app/components/spreadsheet/cell.rb
@@ -8,7 +8,7 @@ module Spreadsheet
     include Spreadsheet::Cell::Controller
     include Spreadsheet::Cell::Menu
 
-    with_content_areas :actions_menu
+    renders_one :cell_actions_menu
 
     def initialize(id:, value: '&nbsp;'.html_safe, colspan: 1, **opts)
       @id = id

--- a/app/components/spreadsheet/header.haml
+++ b/app/components/spreadsheet/header.haml
@@ -7,11 +7,11 @@
     %sl-dropdown.absolute.p-2.inset-y-0.right-0.min-h-full
       .text-gray-100.text-gray-100.cursor-pointer.my-auto(slot="trigger")
         %sl-icon{ name: "three-dots" }
-      = actions_menu
+      = header_actions_menu
 
   %sl-menu#context-menu.hidden.text-xs{data: {"#{component_controller}": { target: "contextMenu" }}}
     - if show_context_menu?
-      = context_menu
+      = header_context_menu
     - else
       %sl-menu-label.text-left.text-xs Show/Hide Columns
       - columns.each do |column|

--- a/app/components/spreadsheet/header.rb
+++ b/app/components/spreadsheet/header.rb
@@ -7,7 +7,8 @@ module Spreadsheet
   class Header < Row
     attr_reader :columns, :locked
 
-    with_content_areas :actions_menu, :context_menu
+    renders_one :header_actions_menu
+    renders_one :header_context_menu
 
     def initialize(id:, columns: [], locked: {}, **opts)
       super
@@ -50,7 +51,7 @@ module Spreadsheet
     end
 
     def show_context_menu?
-      context_menu.present?
+      header_context_menu.present?
     end
 
     private

--- a/app/components/spreadsheet/row.haml
+++ b/app/components/spreadsheet/row.haml
@@ -20,4 +20,4 @@
               .text-xs.col-span-1.p-1
                 %sl-icon{ name: "pencil" }
 
-        = actions_menu
+        = row_actions_menu

--- a/app/components/spreadsheet/row.rb
+++ b/app/components/spreadsheet/row.rb
@@ -5,7 +5,7 @@ module Spreadsheet
   class Row < Spreadsheet::BaseComponent
     attr_reader :id, :parent, :opts
 
-    with_content_areas :actions_menu
+    renders_one :row_actions_menu
 
     def initialize(id:, visible_cells: [], **opts)
       @id = id
@@ -47,7 +47,7 @@ module Spreadsheet
     end
 
     def show_dropdown?
-      selectable_menu || actions_menu.present?
+      selectable_menu || row_actions_menu.present?
     end
 
     private

--- a/app/components/spreadsheet/row_group.haml
+++ b/app/components/spreadsheet/row_group.haml
@@ -1,6 +1,6 @@
 .spreadsheet--row-group-container.pb-px.bg-white{class: classnames, draggable: draggable }
   .spreadsheet--row-group.divide-y.divide-gray-500{ data: data }
     .row_group-header.relative.pb-px.bg-gray-300.font-medium
-      = header
+      = row_group_header
     .row_group-body.collapse-container.bg-white.font-light{ data: sortable_data }
-      = body
+      = row_group_body

--- a/app/components/spreadsheet/row_group.rb
+++ b/app/components/spreadsheet/row_group.rb
@@ -5,7 +5,8 @@ module Spreadsheet
   class RowGroup < Spreadsheet::BaseComponent
     attr_reader :id, :opts
 
-    with_content_areas :header, :body
+    renders_one :row_group_header
+    renders_one :row_group_body
 
     def initialize(id:, **opts)
       @id = id

--- a/test/components/spreadsheet/cell_test.rb
+++ b/test/components/spreadsheet/cell_test.rb
@@ -17,7 +17,7 @@ class CellTest < ViewComponent::TestCase
 
   def test_renders_actions_menu
     render_inline(::Spreadsheet::Cell.new(id: 'cell-test')) do |component|
-      component.with(:actions_menu, 'Menu')
+      component.with_cell_actions_menu { 'Menu' }
     end
     assert_selector('.cell_actionmenu')
   end

--- a/test/components/spreadsheet/header_test.rb
+++ b/test/components/spreadsheet/header_test.rb
@@ -17,7 +17,7 @@ class HeaderTest < ViewComponent::TestCase
                     id: 'header-test',
                     columns: %i[column0 column1 column2]
                   )) do |component|
-      component.with(:actions_menu, 'Header Menu')
+      component.with_header_actions_menu { 'Header Menu' }
     end
 
     assert_selector('sl-dropdown', text: 'Header Menu')

--- a/test/components/spreadsheet/row_test.rb
+++ b/test/components/spreadsheet/row_test.rb
@@ -26,7 +26,7 @@ class RowTest < ViewComponent::TestCase
 
   def test_actions_menu
     render_inline(::Spreadsheet::Row.new(id: 'row-test')) do |component|
-      component.with(:actions_menu, 'Row Menu')
+      component.with_row_actions_menu { 'Row Menu' }
     end
     assert_selector('.row_actionmenu')
     assert_selector('sl-menu', text: 'Row Menu')


### PR DESCRIPTION
Quick info
---

Replace the use of `with_content_areas`  method with ViewComponent `Slots`.

Migrations?
---

:-1:

What does this change?
---

- [x] Implement ViewComponent Slots for sub-sections of the components.

Why are you changing that?
---

The `with_content_areas` method was deprecated in the version 2.30.0 of ViewComponent and will be removed in the version 3.0. They suggest to use `Slots`.

Some of the components were using with_content_areas for rendering some of their section, now they are using Slots.