### PR TITLE
Fix hash as keyword arguments for Ruby 3

### DIFF
--- a/app/components/spreadsheet/header.rb
+++ b/app/components/spreadsheet/header.rb
@@ -71,7 +71,7 @@ module Spreadsheet
     end
 
     def default_column(column)
-      Spreadsheet::HeaderColumn.new(column_hash(column))
+      Spreadsheet::HeaderColumn.new(**column_hash(column))
     end
 
     def normalize_hash(column)


### PR DESCRIPTION
Quick info
---

Fix the issue for when passing a Hash object as keyword arguments in Ruby 3.

references: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Migrations?
---

:-1:

What does this change?
---

Uses the double splat operator for passing a Hash object as keyword arguments.

Why are you changing that?
---

Ruby 3 separates positional arguments from keyword arguments. Passing keyword arguments as the last hash parameter is now deprecated.

Now you can use the double splat operator to pass keyword arguments instead of a Hash value.