### PR TITLE
Fix spreadsheet header dropdown

### DIFF
--- a/app/components/spreadsheet/header.rb
+++ b/app/components/spreadsheet/header.rb
@@ -54,6 +54,10 @@ module Spreadsheet
       header_context_menu.present?
     end
 
+    def show_dropdown?
+      selectable_menu || header_actions_menu.present?
+    end
+
     private
 
     def default_component_controller


### PR DESCRIPTION
Quick info
---

Fix the dropdown menu of the spreadsheet header.

Migrations?
---

:-1:

Why are you changing that?
---

The header can show a general dropdown menu when it is sent by the user. Since the repository was updated to use ViewComponent Slots, the dropdown has not been shown anymore. This is because the method that conditionally shows the dropdown was pointing to a slot of the parent instead of the slot in the header itself.